### PR TITLE
Shut the Box bugfix

### DIFF
--- a/src/tel/discord/rtab/games/ShutTheBox.java
+++ b/src/tel/discord/rtab/games/ShutTheBox.java
@@ -314,9 +314,8 @@ public class ShutTheBox extends MiniGameWrapper {
 	public int rollValue(int roll) {
 		if (waysToClose[roll-2] == 0)
 			return getMoneyWon() * -1;
-		if (totalShut + roll == MAX_SCORE)
-			return applyBaseMultiplier(1500000 - getMoneyWon());
-		return applyBaseMultiplier(findNthTetrahedralNumber(totalShut+roll) * 50) - getMoneyWon();
+		// The base multiplier should **NOT** be applied to the difference; it is already applied to the operands.
+		return getMoneyWon(totalShut+roll) - getMoneyWon();
 	}
 	
 	public int findNthTetrahedralNumber(int n) {
@@ -325,8 +324,13 @@ public class ShutTheBox extends MiniGameWrapper {
 
 	public int getMoneyWon()
 	{
-		if (totalShut == MAX_SCORE)
+		return getMoneyWon(totalShut);
+	}
+
+	public int getMoneyWon(int score)
+	{
+		if (score == MAX_SCORE)
 			return applyBaseMultiplier(1500000);
-		else return applyBaseMultiplier(findNthTetrahedralNumber(totalShut) * 50);
+		else return applyBaseMultiplier(findNthTetrahedralNumber(score) * 50);
 	}
 }

--- a/src/tel/discord/rtab/games/ShutTheBox.java
+++ b/src/tel/discord/rtab/games/ShutTheBox.java
@@ -316,7 +316,7 @@ public class ShutTheBox extends MiniGameWrapper {
 			return getMoneyWon() * -1;
 		if (totalShut + roll == MAX_SCORE)
 			return applyBaseMultiplier(1500000 - getMoneyWon());
-		return applyBaseMultiplier(findNthTetrahedralNumber(totalShut+roll) * 50 - getMoneyWon());
+		return applyBaseMultiplier(findNthTetrahedralNumber(totalShut+roll) * 50) - getMoneyWon();
 	}
 	
 	public int findNthTetrahedralNumber(int n) {


### PR DESCRIPTION
The amount awarded by each roll after the first was being displayed incorrectly when a base multiplier was applied; now it should be correct.