### PR TITLE
Fix display bug in Deuces Wild

### DIFF
--- a/src/tel/discord/rtab/games/DeucesWild.java
+++ b/src/tel/discord/rtab/games/DeucesWild.java
@@ -77,6 +77,8 @@ public class DeucesWild extends MiniGameWrapper
 					redrawUsed = false;
 					output.add("Stopping would prevent you from winning anything. Hold at least one card, then type 'DEAL'.");
 				} else {
+					for (int i = 0; i < cardsHeld.length, i++)
+						cardsHeld[i] = true;
 					redrawUsed = true;
 					output.add(generateBoard(true));
 				}


### PR DESCRIPTION
If you declined to redraw, it wouldn't display your hand at the end; this fixes that error.