### PR TITLE
Fix amount shorthand bug

### DIFF
--- a/src/tel/discord/rtab/games/MoneyCards.java
+++ b/src/tel/discord/rtab/games/MoneyCards.java
@@ -122,7 +122,7 @@ public class MoneyCards extends MiniGameWrapper {
 		
 		if (tokens[0].toUpperCase().charAt(tokens[0].length() - 1) == 'K')
 		{
-			playNextTurn(tokens[0].substring(0, tokens[0].length() - 2) + "000 " + tokens[1]);
+			playNextTurn(tokens[0].substring(0, tokens[0].length() - 1) + "000 " + tokens[1]);
 			return;
 		}
 


### PR DESCRIPTION
An off-by-one error was causing bets using the K shorthand to be recognized as only a tenth of what they should be. This corrects it.