### PR TITLE
Fix Deuces Wild bug

### DIFF
--- a/src/tel/discord/rtab/games/DeucesWild.java
+++ b/src/tel/discord/rtab/games/DeucesWild.java
@@ -212,6 +212,15 @@ public class DeucesWild extends MiniGameWrapper
 					endTurn(output);
 					return;
 				}
+				for (int j = i + 1; i < tokens.length; j++)
+				{
+					if (tokens[j].equals(tokens[i]))
+					{
+						output.add("You cannot draw the same card more than once.");
+						endTurn(output);
+						return;
+					}
+				}
 			}
 			for(String nextPick : tokens)
 			{

--- a/src/tel/discord/rtab/games/DeucesWild.java
+++ b/src/tel/discord/rtab/games/DeucesWild.java
@@ -291,7 +291,7 @@ public class DeucesWild extends MiniGameWrapper
 	private boolean checkValidNumber(String message)
 	{
 		int location = Integer.parseInt(message)-1;
-		return (location >= 0 && location < BOARD_SIZE && !pickedSpaces[location]);
+		return (location >= 0 && location < BOARD_SIZE);
 	}
 	
 	private String generateBoard(boolean reveal)

--- a/src/tel/discord/rtab/games/DeucesWild.java
+++ b/src/tel/discord/rtab/games/DeucesWild.java
@@ -212,15 +212,6 @@ public class DeucesWild extends MiniGameWrapper
 					endTurn(output);
 					return;
 				}
-				for (int j = i + 1; i < tokens.length; j++)
-				{
-					if (tokens[j].equals(tokens[i]))
-					{
-						output.add("You cannot draw the same card more than once.");
-						endTurn(output);
-						return;
-					}
-				}
 			}
 			for(String nextPick : tokens)
 			{
@@ -228,7 +219,12 @@ public class DeucesWild extends MiniGameWrapper
 				if(gameStage == 5)
 					break;
 				lastSpace = Integer.parseInt(nextPick)-1;
-				pickedSpaces[lastSpace] = true;
+				if(pickedSpaces[lastSpace]) {
+					output.add("You cannot draw the same card more than once.");
+					endTurn(output);
+					return;
+				}
+				else pickedSpaces[lastSpace] = true;
 				lastPicked = board.get(lastSpace);
 				cardsPicked[gameStage] = lastPicked;
 				//Autohold deuces, or any card once we've already redrawn

--- a/src/tel/discord/rtab/games/DeucesWild.java
+++ b/src/tel/discord/rtab/games/DeucesWild.java
@@ -221,8 +221,7 @@ public class DeucesWild extends MiniGameWrapper
 				lastSpace = Integer.parseInt(nextPick)-1;
 				if(pickedSpaces[lastSpace]) {
 					output.add("You cannot draw the same card more than once.");
-					endTurn(output);
-					return;
+					break;
 				}
 				else pickedSpaces[lastSpace] = true;
 				lastPicked = board.get(lastSpace);


### PR DESCRIPTION
If you picked the same unselected card twice in the same string, it'd let you draw it twice, and cards are not allowed to repeat.