### PR TITLE
Properly handle InterruptedException

### DIFF
--- a/src/tel/discord/rtab/GameController.java
+++ b/src/tel/discord/rtab/GameController.java
@@ -763,7 +763,7 @@ public class GameController
 		//There is NO reason why we should be running a turn for anyone other than the current player
 		if(player != currentTurn)
 			return;
-		try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
         //If wagers have been queued, resolve those first
         while(queuedWagers > 0)
         {
@@ -819,7 +819,7 @@ public class GameController
 		if(players.get(player).isBot)
 		{
 			//Sleep for a couple of seconds so they don't rush
-			try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			//and their logic is complicated so they get their own method
 			runAITurn(player);
 		}
@@ -1146,7 +1146,7 @@ public class GameController
 			players.get(player).warned = true;
 			channel.sendMessage(players.get(player).getSafeMention() + 
 					" is out of time. Discarding a random space.").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			//Get unpicked spaces
 			ArrayList<Integer> spaceCandidates = new ArrayList<>(boardSize);
 			for(int i=0; i<boardSize; i++)
@@ -1176,7 +1176,7 @@ public class GameController
 						.queueAfter(1,TimeUnit.SECONDS);
 					players.get(player).addMoney(applyBaseMultiplier(-1*THRESHOLD_PER_TURN_PENALTY),MoneyMultipliersToUse.NOTHING);
 				}
-				try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+				try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 				channel.sendMessage("It's not a bomb, so its contents are lost.").queue();
 				runEndTurnLogic();
 			}
@@ -1246,7 +1246,7 @@ public class GameController
 		}
 		else
 		{
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			channel.sendMessage("Space " + (location+1) + " selected...").queue();
 		}
 		pickedSpaces[location] = true;
@@ -1286,10 +1286,10 @@ public class GameController
 		if((Math.random()*Math.min(spacesLeft,fcTurnsLeft)<players.size() && players.get(player).jokers == 0 && !starman)
 				|| gameboard.getType(location) == SpaceType.BLAMMO || gameboard.getType(location).isBomb())
 		{
-			try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			channel.sendMessage("...").queue();
 		}
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		switch (gameboard.getType(location)) {
 			case BOMB -> {
 				//Start off by sending the appropriate message
@@ -1315,25 +1315,25 @@ public class GameController
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				}
 				awardGame(player, gameboard.getGame(location));
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				}
 				awardBoost(player, gameboard.getBoost(location));
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				}
 				awardCash(player, gameboard.getCash(location));
 				try {
 					Thread.sleep(2000);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				} //mini-suspense lol
 				awardEvent(player, gameboard.getEvent(location));
 			}
@@ -1342,25 +1342,25 @@ public class GameController
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				}
 				awardGame(player, gameboard.getGame(location));
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				}
 				awardBoost(player, gameboard.getBoost(location));
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				}
 				awardCash(player, gameboard.getCash(location));
 				try {
 					Thread.sleep(3500);
 				} catch (InterruptedException e) {
-					e.printStackTrace();
+					Thread.currentThread().interrupt();
 				} //mega-mini-suspense lololol
 				if (players.get(player).knownBombs.contains(location)) {
 					//Mock them appropriately if they self-bombed
@@ -1391,7 +1391,7 @@ public class GameController
 		{
 			channel.sendMessage("But you have a joker!").queueAfter(2,TimeUnit.SECONDS);
 			channel.sendMessage("It goes _\\*fizzle*_.").queueAfter(5,TimeUnit.SECONDS);
-			try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			//Don't deduct if negative, to allow for unlimited joker
 			if(players.get(player).jokers > 0)
 				players.get(player).jokers --;
@@ -1401,7 +1401,7 @@ public class GameController
 		{
 			resolvingBomb = true;
 			int penalty = calculateBombPenalty(player);
-			try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			//Pass control to the bomb itself to deal some damage
 			bombType.getBomb().explode(this, player, penalty);
 			resolvingBomb = false;
@@ -1416,7 +1416,7 @@ public class GameController
 		if(cashType == Cash.MYSTERY)
 		{
 			channel.sendMessage("It's **Mystery Money**, and this time it awards you...").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			if(Math.random() < 0.1)
 				cashWon = -1*(int)Math.pow((Math.random()*39)+1,3);
 			else
@@ -1453,7 +1453,7 @@ public class GameController
 		StringBuilder extraResult = players.get(player).addMoney(cashWon, MoneyMultipliersToUse.BOOSTER_ONLY);
 		if(extraResult != null)
 		{
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			channel.sendMessage(extraResult.toString()).queue();
 		}
 		//Award hidden command with 40% chance if cash is negative and they don't have one already
@@ -1744,7 +1744,7 @@ public class GameController
 			gameStatus = GameStatus.END_GAME;
 		if(spacesLeft < 0)
 			channel.sendMessage("An error has occurred, ending the game, @telna fix pls").queue();
-		try { Thread.sleep(3000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(3000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//Keep this one as complete since it's such an important spot
 		channel.sendMessage("Game Over.").complete();
 		currentBlammo = false;
@@ -1974,7 +1974,7 @@ public class GameController
 				channel.sendMessage("BUT THERE CAN BE ONLY ONE.").completeAfter(5,TimeUnit.SECONDS);
 				channel.sendMessage("@everyone, **PREPARE FOR THE FINAL SHOWDOWN!**").completeAfter(5,TimeUnit.SECONDS);
 				channel.sendMessage("(And no peeks for you!)").queue();
-				try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+				try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 				//Prepare the game
 				tiebreakMode = true;
 				for(Player next : winners)
@@ -2520,7 +2520,7 @@ public class GameController
 	{
 		Player failsafeUser = players.get(player);
 		channel.sendMessage(failsafeUser.getName() + " has engaged the failsafe...").queue();
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		failsafeUser.hiddenCommand = HiddenCommand.NONE;
 		//Search for any unpicked non-bomb spaces
 		boolean success = true;
@@ -2550,7 +2550,7 @@ public class GameController
 		{
 			//If it's not all bombs, get owned
 			channel.sendMessage("But there is still at least one safe space.").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			int fine = applyBaseMultiplier(1_000_000);
 			channel.sendMessage(failsafeUser.getName() + String.format(" was fined $%,d.",fine)).queue();
 			failsafeUser.addMoney(-1*fine, MoneyMultipliersToUse.NOTHING);

--- a/src/tel/discord/rtab/bombs/BankruptBomb.java
+++ b/src/tel/discord/rtab/bombs/BankruptBomb.java
@@ -14,9 +14,9 @@ public class BankruptBomb implements Bomb
 		else
 		{
 			game.channel.sendMessage("It goes **BOOM**...").queue();
-			try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage("It also goes **BANKRUPT**. _\\*whoosh*_").queue();
-			try { Thread.sleep(3000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(3000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			if(amountLost < 0)
 			{
 				game.channel.sendMessage(String.format("**$%1$,d** *returned*, plus $%2$,d penalty.",

--- a/src/tel/discord/rtab/bombs/Bomb.java
+++ b/src/tel/discord/rtab/bombs/Bomb.java
@@ -10,7 +10,7 @@ public interface Bomb
 		if(Math.random() < 0.05)
 		{
 			game.channel.sendMessage("It goes **BOOM**...").queue();
-			try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage(String.format("$%,d lost as penalty.",Math.abs(penalty))).queue();
 		}
 		//But most of the time, just blow them up

--- a/src/tel/discord/rtab/bombs/BoostBlast.java
+++ b/src/tel/discord/rtab/bombs/BoostBlast.java
@@ -8,7 +8,7 @@ public class BoostBlast implements Bomb
 	public void explode(GameController game, int victim, int penalty)
 	{
 		game.channel.sendMessage("It goes **BOOM**...").queue();
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		if (game.playersAlive > 1 && game.players.get(victim).booster > 100)
 		{
 			int excessBoost = game.players.get(victim).booster - 100;

--- a/src/tel/discord/rtab/bombs/ClusterBomb.java
+++ b/src/tel/discord/rtab/bombs/ClusterBomb.java
@@ -11,7 +11,7 @@ public class ClusterBomb implements Bomb
 		do
 		{
 			chain *= 2;
-			try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			if(chain <= 398) //A bomb bigger than this would exceed Discord's character limit
 			{
 				StringBuilder nextLevel = new StringBuilder();
@@ -31,14 +31,14 @@ public class ClusterBomb implements Bomb
 			}
 			else //Congratulations on being the unluckiest player in the world (a 1/68,719,476,736 chance)
 			{
-				try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+				try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 				game.channel.sendMessage("...").queue();
-				try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+				try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 				game.channel.sendMessage(game.players.get(victim).getName()+" was disintegrated by the force of the bomb.").queue();
 			}
 		}
 		while(Math.random() * chain < 1 && chain <= 398);
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		if(chain <= 398)
 		{
 			game.channel.sendMessage(String.format("**$%,d** penalty!",Math.abs(chain*penalty))).queue();

--- a/src/tel/discord/rtab/bombs/LoserWheelBomb.java
+++ b/src/tel/discord/rtab/bombs/LoserWheelBomb.java
@@ -8,7 +8,7 @@ public class LoserWheelBomb implements Bomb
 	public void explode(GameController game, int victim, int penalty)
 	{
 		game.channel.sendMessage("It goes **BOOM**...").queue();
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("with a penalty to be determined later.").queue();
 		game.players.get(victim).blowUp(0,false);
 		game.awardGame(victim, Game.LOSER_WHEEL);

--- a/src/tel/discord/rtab/bombs/ReverseBomb.java
+++ b/src/tel/discord/rtab/bombs/ReverseBomb.java
@@ -10,7 +10,7 @@ public class ReverseBomb implements Bomb
 	public void explode(GameController game, int victim, int penalty)
 	{
 		game.channel.sendMessage("It goes **BOOM**...").queue();
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage(String.format("But it's a REVERSE bomb. $%,d awarded to living players!",Math.abs(penalty))).queue();
 		game.players.get(victim).blowUp(0,false);
 		for(Player nextPlayer : game.players)

--- a/src/tel/discord/rtab/bombs/StreakBlast.java
+++ b/src/tel/discord/rtab/bombs/StreakBlast.java
@@ -9,7 +9,7 @@ public class StreakBlast implements Bomb
 	public void explode(GameController game, int victim, int penalty)
 	{
 		game.channel.sendMessage("It goes **BOOM**...").queue();
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		if (game.playersAlive > 1 && game.players.get(victim).winstreak > 10)
 		{
 			int excessStreak = game.players.get(victim).winstreak - 10;

--- a/src/tel/discord/rtab/commands/mod/SendMessagesCommand.java
+++ b/src/tel/discord/rtab/commands/mod/SendMessagesCommand.java
@@ -39,7 +39,7 @@ public class SendMessagesCommand extends Command
 		}
 		//We just opened the private channel by sending the command lol
 		myChannel = event.getAuthor().openPrivateChannel().complete();
-		try { Thread.sleep(500); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(500); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		getMessage();
 	}
 	

--- a/src/tel/discord/rtab/events/BoostMagnet.java
+++ b/src/tel/discord/rtab/events/BoostMagnet.java
@@ -39,9 +39,9 @@ public class BoostMagnet implements EventSpace
 		{
 			//No boost in play? BACKUP PLAN
 			game.channel.sendMessage("It's a **Boost Magnet**, but there's no boost to steal...").queue();
-			try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage("So you can have this instead.").queue();
-			try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.awardBoost(player, Board.generateSpaces(1, game.players.size(), Boost.values()).get(0));
 		}
 	}

--- a/src/tel/discord/rtab/events/Bowser.java
+++ b/src/tel/discord/rtab/events/Bowser.java
@@ -80,22 +80,22 @@ public class Bowser implements EventSpace
 		if(Math.random() < 0.01 && getCurrentPlayer().getRoundDelta() > 0)
 		{
 			game.channel.sendMessage("It's ||B-B-B-**BOWSER**||!").queue();
-			try { Thread.sleep(3000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(3000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage("Wah, hah, HAH! Welcome to the **Bowser Event**! Aww, did I fool you?").queue();
 		}
 		else
 		{
 			game.channel.sendMessage("It's B-B-B-**BOWSER**!!").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage(String.format(INTRO_MESSAGES[(int)(Math.random()*INTRO_MESSAGES.length)],
 					getCurrentPlayer().getName())).queue();
 		}
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//If they don't have any money yet, why not be kind and give them some?
 		if(getCurrentPlayer().getRoundDelta() <= 0)
 		{
 			game.channel.sendMessage("Oh, but you don't have any money yet this round?").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			//100% chance of pity money at start, then 90% chance for $100M club, down to 10% chance in $900M club
 			if(Math.random()*10 > getCurrentPlayer().money / 100_000_000)
 			{
@@ -111,7 +111,7 @@ public class Bowser implements EventSpace
 		{
 			game.channel.sendMessage(EVENT_MESSAGES[(int)(Math.random()*EVENT_MESSAGES.length)]).queue();
 		}
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage(ROULETTE_MESSAGES[(int)(Math.random()*ROULETTE_MESSAGES.length)]).queue();
 		//Build roulette wheel
 		ArrayList<BowserEvent> bowserEvents = new ArrayList<>();
@@ -156,7 +156,7 @@ public class Bowser implements EventSpace
 						try {
 							Thread.sleep(2000);
 						} catch (InterruptedException e) {
-							e.printStackTrace();
+							Thread.currentThread().interrupt();
 						}
 						game.channel.sendMessage("...with all your money. Jackpot!").queue();
 						bowserJackpot += getCurrentPlayer().resetRoundDelta();
@@ -179,7 +179,7 @@ public class Bowser implements EventSpace
 		{
 			index += 1;
 			index %= 5;
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			bowserMessage.editMessage(generateRouletteDisplay(list,index)).queue();
 		}
 		//50% chance three times to give it an extra twist
@@ -192,7 +192,7 @@ public class Bowser implements EventSpace
 				bowserMessage.editMessage(generateRouletteDisplay(list,index)).completeAfter(2,TimeUnit.SECONDS);
 			}
 		//Pause for a second
-		try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//Check if it's on the jackpot or runaway
 		if(list.get(index).hardToLandOn)
 		{
@@ -208,7 +208,7 @@ public class Bowser implements EventSpace
 					index += direction ? 1 : -1;
 					index = (index + 5) % 5;
 					bowserMessage.editMessage(generateRouletteDisplay(list,index)).queue();
-					try { Thread.sleep(250); } catch (InterruptedException e) { e.printStackTrace(); }
+					try { Thread.sleep(250); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 				}
 			}
 		}
@@ -236,7 +236,7 @@ public class Bowser implements EventSpace
 	private void coinsForBowser()
 	{
 		game.channel.sendMessage("**Cash for Bowser** it is!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("In this FUN event, you give your money to ME!").queue();
 		//Coins: Up to 100-200% of the base amount, determined by their round earnings and their total bank
 		int coinFraction = (int)(Math.random()*51+50);
@@ -249,7 +249,7 @@ public class Bowser implements EventSpace
 		int minimumTake = game.applyBaseMultiplier(50_000);
 		if(coins < minimumTake)
 			coins = minimumTake;
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage(String.format("Ooh! I'm so excited! OK, that'll be **$%,d**! Wah, hah, hah, HAH!"
 				,coins)).queue();
 		getCurrentPlayer().addMoney(coins*-1,MoneyMultipliersToUse.NOTHING);
@@ -258,7 +258,7 @@ public class Bowser implements EventSpace
 	private void bowserPotluck()
 	{
 		game.channel.sendMessage("It's **Bowser's Cash Potluck**!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("In this EXTRA FUN event, EVERY PLAYER gives me money!").queue();
 		//Potluck: 0.01% - 1.00% of the average total bank of the living players in the round
 		int potluckFraction = (int)(Math.random()*100+1);
@@ -272,7 +272,7 @@ public class Bowser implements EventSpace
 		if(potluck < 50000)
 			potluck = 50000;
 		potluck = game.applyBaseMultiplier(potluck);
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage(String.format("Let the event begin! That'll be **$%,d** each! Wah, hah, hah, HAH!"
 				,potluck)).queue();
 		for(Player next : game.players)
@@ -283,15 +283,15 @@ public class Bowser implements EventSpace
 	private void communism()
 	{
 		game.channel.sendMessage("I am not always thinking about money. Why can't we all be friends?").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("So, to make the world a more peaceful place, "
 			+ "I've decided to *divide everyone's earnings evenly*!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("It's a **Bowser Revolution**!").queue();
 		boolean superRevolution = Math.random() < 0.5;
 		if(superRevolution)
 		{
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage("And let's throw in 1% of your total banks as well!").queue();
 		}
 		//Get the total money added during the round
@@ -350,7 +350,7 @@ public class Bowser implements EventSpace
 	private void reverseCurse()
 	{
 		game.channel.sendMessage("It's **Bowser's Reverse Curse**!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("You've all been cursed to go in reverse... and I'm adding *lots* of Reverse!").queue();
 		game.gameboard.eventCurse(EventType.REVERSE);
 		game.reverse = !game.reverse;
@@ -358,7 +358,7 @@ public class Bowser implements EventSpace
 	private void addCursedBombs()
 	{
 		game.channel.sendMessage("It's **Bowser's Cursed Bombs**!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("You've been CURSED... and there are two new bombs on the board that only you can hit!").queue();
 		int bombsToPlace = Math.min(2, game.spacesLeft);
 		int[] cursedBombs = new int[bombsToPlace];
@@ -375,22 +375,22 @@ public class Bowser implements EventSpace
 	}
 	private void runaway()
 	{
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("...").queue();
-		try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("Bowser ran away!").queue();
 	}
 	private void awardJackpot()
 	{
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("...").queue();
-		try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("Bowser looks about to run away, but then gives you a pitiful look.").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("You're looking quite sad there, aren't you?").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("Let no one say I am unkind. You can have this, but don't tell anyone...").queue();
-		try { Thread.sleep(3000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(3000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//Final test: They need to be in last overall out of the players in the round
 		boolean awardJP = true;
 		int threshold = getCurrentPlayer().money;

--- a/src/tel/discord/rtab/events/CursedBomb.java
+++ b/src/tel/discord/rtab/events/CursedBomb.java
@@ -26,7 +26,7 @@ public class CursedBomb implements EventSpace
 		else
 		{
 			game.channel.sendMessage("It's a **CURSED BOMB**, but you aren't cursed...").queue();
-			try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			//Get a list of cursed players
 			LinkedList<Integer> cursedPlayers = new LinkedList<>();
 			for(int i=0; i<game.players.size(); i++)
@@ -48,7 +48,7 @@ public class CursedBomb implements EventSpace
 			}
 			for(int next : cursedPlayers)
 			{
-				try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+				try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 				//Steal a bomb penalty from the cursed player (and use the cursed player's booster, NOT the triggering player)
 				int originalTheftAmount = game.calculateBombPenalty(next) * 4;
 				int theftAmount = game.players.get(next).calculateBoostedAmount(originalTheftAmount, MoneyMultipliersToUse.BOOSTER_ONLY);

--- a/src/tel/discord/rtab/events/HiddenCommandsForAll.java
+++ b/src/tel/discord/rtab/events/HiddenCommandsForAll.java
@@ -18,7 +18,7 @@ public class HiddenCommandsForAll implements EventSpace
 		if(game.tiebreakMode)
 		{
 			game.channel.sendMessage("It's ||**Commands for None**||!").queue();
-			try { Thread.sleep(3000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(3000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage("Win the season on your own merit, not on hidden command RNG :)").queue();
 			return;
 		}	

--- a/src/tel/discord/rtab/events/LuckySpace.java
+++ b/src/tel/discord/rtab/events/LuckySpace.java
@@ -53,7 +53,7 @@ public class LuckySpace implements EventSpace
 			wheel.remove(LuckyEvent.DOUBLE_DEAL);
 		Collections.shuffle(wheel);
 		game.channel.sendMessage("You found the **Lucky Space**! Step right up and claim your prize!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		switch (spinWheel(wheel)) {
 			case BIG_BUCKS -> {
 				int cashWon = (int) Math.pow((Math.random() * 14) + 20, 4); //Mystery money but with a much more limited range
@@ -66,7 +66,7 @@ public class LuckySpace implements EventSpace
 					try {
 						Thread.sleep(1000);
 					} catch (InterruptedException e) {
-						e.printStackTrace();
+						Thread.currentThread().interrupt();
 					}
 					game.channel.sendMessage(extraResult.toString()).queue();
 				}
@@ -97,18 +97,18 @@ public class LuckySpace implements EventSpace
 		{
 			index += 1;
 			index %= wheel.size();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			luckyMessage.editMessage(generateRouletteDisplay(wheel,index)).queue();
 		}
 		//50% chance to tick it over one more time
-		try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		if(Math.random() < 0.5)
 		{
 			index += 1;
 			index %= wheel.size();
 			luckyMessage.editMessage(generateRouletteDisplay(wheel,index)).queue();
 		}
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//Delete the roulette message after a few seconds
 		luckyMessage.delete().queueAfter(5, TimeUnit.SECONDS);
 		return wheel.get(index);

--- a/src/tel/discord/rtab/events/Market.java
+++ b/src/tel/discord/rtab/events/Market.java
@@ -408,7 +408,7 @@ public class Market implements EventSpace
 		this.game = game;
 		this.player = player;
 		game.channel.sendMessage("It's the **RtaB Market**!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//Decide on basic offerings
 		validOptions = new LinkedList<>();
 		int boostBuyable = getCurrentPlayer().getRoundDelta() / game.applyBaseMultiplier(BUY_BOOST_PRICE);
@@ -450,7 +450,7 @@ public class Market implements EventSpace
 		if(!getCurrentPlayer().isBot)
 			while(status != EventStatus.FINISHED)
 			{
-				try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); status = EventStatus.FINISHED; }
+				try { Thread.sleep(2000); } catch (InterruptedException e) { status = EventStatus.FINISHED; Thread.currentThread().interrupt(); }
 			}
 		//Once it's finished, the execute method ends and control passes back to the game controller
 	}
@@ -498,7 +498,7 @@ public class Market implements EventSpace
 			shopMenu.append(String.format("\nCHAOS - %s\n      (Cost: %s)\n", chaosOption.getReward(game, player),chaosOption.getRisk(game, player)));
 			//Build up suspense
 			game.channel.sendMessage(":warning: **WARNING: CHAOS OPTION DETECTED** :warning:").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		}
 		if(firstTime) //Can't rob the market if you've already started shopping
 		{
@@ -519,7 +519,7 @@ public class Market implements EventSpace
 			game.channel.sendMessage(getCurrentPlayer().getSafeMention()+", you have ninety seconds to make a selection!").queue();
 		else
 			game.channel.sendMessage(getCurrentPlayer().getSafeMention()+", would you like to buy more?").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage(shopMenu.toString()).queue();
 		//Find out what we're doing
 		if(getCurrentPlayer().isBot)
@@ -571,7 +571,7 @@ public class Market implements EventSpace
 		status = EventStatus.RESOLVING;
 		//Removing one-chance options from the list no matter what they chose so they aren't offered again
 		validOptions.removeAll(Arrays.asList("CHAOS", "BUY LIFE", "ROB ROCK","ROB PAPER","ROB SCISSORS"));
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		switch(choice)
 		{
 		case "BUY BOOST":
@@ -715,7 +715,7 @@ public class Market implements EventSpace
 	{
 		game.channel.sendMessage("You confidently stride up to the shopkeeper with your trusty "+weapon.toString().toLowerCase()
 				+", intent on stealing as much as you can...").queue();
-		try { Thread.sleep(5000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(5000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//you know rtab has gone too far when you're writing rock-paper-scissors fanfiction
 		//...or not far enough? (-JerryEris)
 		switch (weapon) {
@@ -726,7 +726,7 @@ public class Market implements EventSpace
 						try {
 							Thread.sleep(5000);
 						} catch (InterruptedException e) {
-							e.printStackTrace();
+							Thread.currentThread().interrupt();
 						}
 						switch (backupWeapon) {
 							case PAPER -> {
@@ -765,7 +765,7 @@ public class Market implements EventSpace
 						try {
 							Thread.sleep(5000);
 						} catch (InterruptedException e) {
-							e.printStackTrace();
+							Thread.currentThread().interrupt();
 						}
 						switch (backupWeapon) {
 							case ROCK -> {
@@ -801,7 +801,7 @@ public class Market implements EventSpace
 						try {
 							Thread.sleep(5000);
 						} catch (InterruptedException e) {
-							e.printStackTrace();
+							Thread.currentThread().interrupt();
 						}
 						switch (backupWeapon) {
 							case ROCK -> {
@@ -823,27 +823,27 @@ public class Market implements EventSpace
 	void robberySuccess()
 	{
 		//You get a pretty awesome grab bag!
-		try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage("The shopkeeper dealt with, you make off with the following...").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		if(minigameOffered == null)
 			game.awardGame(player, Board.generateSpaces(1, game.players.size(), Game.values()).get(0));
 		else
 			game.awardGame(player, minigameOffered);
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.awardBoost(player, Boost.P150);
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.awardCash(player, Cash.P1000K);
 		if(getCurrentPlayer().hiddenCommand == HiddenCommand.NONE)
 			getCurrentPlayer().awardHiddenCommand();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); } //mini-suspense lol
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); } //mini-suspense lol
 		game.awardEvent(player, EventType.PEEK_REPLENISH);
 		status = EventStatus.FINISHED;
 	}
 	void robberyFailure()
 	{
 		int penalty = game.calculateBombPenalty(player);
-		try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		game.channel.sendMessage(String.format("%s was arrested. $%,d fine.",
 				getCurrentPlayer().getName(), Math.abs(penalty))).queue();
 		StringBuilder extraResult = game.players.get(player).blowUp(penalty,false);

--- a/src/tel/discord/rtab/events/MinigamesForAll.java
+++ b/src/tel/discord/rtab/events/MinigamesForAll.java
@@ -28,7 +28,7 @@ public class MinigamesForAll implements EventSpace
 				game.players.get(player).games.add(chosenGame);
 				game.channel.sendMessage(game.players.get(player).getSafeMention() 
 						+ " receives a copy of **" + chosenGame.getName() + "**!").queue();
-				try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+				try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			}
 			game.players.get(player).games.sort(null);
 			game.players.get(player).minigameLock = true;
@@ -47,7 +47,7 @@ public class MinigamesForAll implements EventSpace
 					game.players.get(i).games.sort(null);
 					game.channel.sendMessage(nextPlayer.getSafeMention() +
 							" receives a copy of **" + chosenGame.getName() + "**!").queue();
-					try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+					try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 				}
 			}
 		}

--- a/src/tel/discord/rtab/events/RevivalChance.java
+++ b/src/tel/discord/rtab/events/RevivalChance.java
@@ -97,12 +97,12 @@ public class RevivalChance implements EventSpace
 		this.game = game;
 		this.player = player;
 		game.channel.sendMessage("You've found the **Revival Chance**!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		//Check if there's anyone to revive in the first place
 		if(game.playersAlive == game.players.size())
 		{
 			game.channel.sendMessage("But no one even needs to be revived...").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			failedRevival();
 		}
 		else
@@ -113,7 +113,7 @@ public class RevivalChance implements EventSpace
 		//Wait for them to be done
 		while(status != EventStatus.FINISHED)
 		{
-			try { Thread.sleep(2000); } catch (InterruptedException e) { e.printStackTrace(); status = EventStatus.FINISHED; }
+			try { Thread.sleep(2000); } catch (InterruptedException e) { status = EventStatus.FINISHED; Thread.currentThread().interrupt(); }
 		}
 		//Once it's finished, the execute method ends and control passes back to the game controller
 	}
@@ -192,13 +192,13 @@ public class RevivalChance implements EventSpace
 		status = EventStatus.RESOLVING;
 		if(!candidates.isEmpty())
 		{
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			playRevivalChance();
 		}
 		else
 		{
 			game.channel.sendMessage("No one wants to be revived...").queue();
-			try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			failedRevival();
 		}
 	}
@@ -214,7 +214,7 @@ public class RevivalChance implements EventSpace
 		Message message = game.channel.sendMessage("Now Reviving: "+targetName+" with no bonus?").completeAfter(1, TimeUnit.SECONDS);
 		while(delay < 2500)
 		{
-			try { Thread.sleep(delay); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(delay); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			revivalTarget = (int)(Math.random() * (candidates.size()+1)) - 1;
 			chosenPrize = RevivalPrize.values()[(int)(Math.random() * RevivalPrize.values().length)];
 			if(revivalTarget == -1)
@@ -224,7 +224,7 @@ public class RevivalChance implements EventSpace
 			message.editMessage("Now Reviving: "+targetName+" with "+chosenPrize.getPrize()+"?").queue();
 			delay += (int)(Math.random()*500);
 		}
-		try { Thread.sleep(2500); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(2500); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		message.editMessage("Now Reviving: **"+targetName+"** with **"+chosenPrize.getPrize()+"**"+(revivalTarget==-1?"...":"!")).queue();
 		if(revivalTarget == -1)
 			failedRevival(chosenPrize);
@@ -241,7 +241,7 @@ public class RevivalChance implements EventSpace
 	{
 		status = EventStatus.RESOLVING;
 		game.channel.sendMessage("We'll just have to give you the bonus instead!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		chosenPrize.awardPrize(game, getCurrentPlayer(), this);
 		if(status == EventStatus.RESOLVING)
 			status = EventStatus.FINISHED;
@@ -263,7 +263,7 @@ public class RevivalChance implements EventSpace
 		target.status = PlayerStatus.ALIVE;
 		game.playersAlive ++;
 		game.channel.sendMessage("Welcome back, "+target.getSafeMention()+"!").queue();
-		try { Thread.sleep(1000); } catch (InterruptedException e) { e.printStackTrace(); }
+		try { Thread.sleep(1000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 		chosenPrize.awardPrize(game, target, this);
 		if(status == EventStatus.RESOLVING)
 			status = EventStatus.FINISHED;

--- a/src/tel/discord/rtab/events/SplitAndShare.java
+++ b/src/tel/discord/rtab/events/SplitAndShare.java
@@ -24,7 +24,7 @@ public class SplitAndShare implements EventSpace
 		else
 		{
 			game.channel.sendMessage("It's a **Split & Share**, but you already have one...").queue();
-			try { Thread.sleep(3000); } catch (InterruptedException e) { e.printStackTrace(); }
+			try { Thread.sleep(3000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 			game.channel.sendMessage("Well then, how about we activate it~?").queue();
 			game.players.get(player).blowUp(0,false);
 		}

--- a/src/tel/discord/rtab/games/BombRoulette.java
+++ b/src/tel/discord/rtab/games/BombRoulette.java
@@ -265,7 +265,7 @@ public class BombRoulette extends MiniGameWrapper {
     		Message wheelMessage = channel.sendMessage(displayRoulette(index)).complete();
     		//Start with a 0.5-second delay
     		int delay = 500 + r.nextInt(500);
-    		try { Thread.sleep(delay); } catch (InterruptedException e) { e.printStackTrace(); }
+    		try { Thread.sleep(delay); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
     		do
     		{
     			//Move along one space on the wheel
@@ -275,7 +275,7 @@ public class BombRoulette extends MiniGameWrapper {
     			wheelMessage.editMessage(displayRoulette(index)).queue();
     			//Then increase the delay randomly, and wait for that amount of time
     			delay += r.nextInt(500);
-    			try { Thread.sleep(delay); } catch (InterruptedException e) { e.printStackTrace(); }
+    			try { Thread.sleep(delay); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
     		}
     		//Stop once we reach a 2.5-second delay
     		while(delay < 2500);

--- a/src/tel/discord/rtab/games/LoserWheel.java
+++ b/src/tel/discord/rtab/games/LoserWheel.java
@@ -143,7 +143,7 @@ public class LoserWheel extends MiniGameWrapper
     		Message wheelMessage = channel.sendMessage(displayRoulette(index)).complete();
     		//Start with a 0.5-second delay
     		int delay = 500 + r.nextInt(250);
-    		try { Thread.sleep(delay); } catch (InterruptedException e) { e.printStackTrace(); }
+    		try { Thread.sleep(delay); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
     		do
     		{
     			//Move along one space on the wheel
@@ -153,7 +153,7 @@ public class LoserWheel extends MiniGameWrapper
     			wheelMessage.editMessage(displayRoulette(index)).queue();
     			//Then increase the delay randomly, and wait for that amount of time
     			delay += r.nextInt(250);
-    			try { Thread.sleep(delay); } catch (InterruptedException e) { e.printStackTrace(); }
+    			try { Thread.sleep(delay); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
     		}
     		//Stop once we reach a 2.5-second delay
     		while(delay < 2500);

--- a/src/tel/discord/rtab/games/RaceDeal.java
+++ b/src/tel/discord/rtab/games/RaceDeal.java
@@ -578,7 +578,7 @@ public class RaceDeal extends MiniGameWrapper
 		for(int i=1; i<=9; i++)
 		{
 			if(!getPlayer().isBot)
-				try { Thread.sleep(1000*i); } catch(InterruptedException e) { e.printStackTrace(); } //Ever-increasing delay
+				try { Thread.sleep(1000*i); } catch(InterruptedException e) { Thread.currentThread().interrupt(); } //Ever-increasing delay
 			sendMessage(String.format("```%n$%,11d%n```", (int)(newScore%(Math.pow(10, i)))));
 		}
 		output.clear();


### PR DESCRIPTION
When catching an InterruptedException, either the thread must be reinterrupted in the catch block or the method must rethrow the InterruptedException. I chose to do the former in lieu of printing the stack trace.