### PR TITLE
Move comment to be inside block

### DIFF
--- a/src/tel/discord/rtab/games/BombRoulette.java
+++ b/src/tel/discord/rtab/games/BombRoulette.java
@@ -354,7 +354,8 @@ public class BombRoulette extends MiniGameWrapper {
 			        else spaceValues[i] = score * -1;
 		        }
 		        default -> {
-		        } // do nothing
+			        // do nothing
+		        }
 	        }
         }
     }


### PR DESCRIPTION
SonarLint prefers blocks to be filled with _something_, even if it's just a comment.